### PR TITLE
Eliminate OpenAI -> Gemini Model Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gemini-OpenAI-Proxy
 
-Gemini-OpenAI-Proxy is a proxy designed to convert the OpenAI API protocol to the Google Gemini Pro protocol. This enables seamless integration of OpenAI-powered functionalities into applications using the Gemini Pro protocol.
+Gemini-OpenAI-Proxy is a proxy designed to convert the OpenAI API protocol to the Google Gemini protocol. This enables applications built for the OpenAI API to seamlessly communicate with the Gemini protocol, including support for Chat Completion, Embeddings, and Model(s) endpoints.
 
 ---
 
@@ -51,7 +51,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
 3. **Integrate the Proxy into Your Application:**
    Modify your application's API requests to target the Gemini-OpenAI-Proxy, providing the acquired Google AI Studio API key as if it were your OpenAI API key.
 
-   Example API Request (Assuming the proxy is hosted at `http://localhost:8080`):
+   Example Chat Completion API Request (Assuming the proxy is hosted at `http://localhost:8080`):
    ```bash
    curl http://localhost:8080/v1/chat/completions \
     -H "Content-Type: application/json" \
@@ -97,6 +97,30 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
     }'
    ```
 
+   Example Embeddings API Request:
+
+   ```bash
+   curl http://localhost:8080/v1/embeddings \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
+    -d '{
+       "model": "ada-002",
+       "input": "This is a test sentence."
+    }'
+   ```
+
+   You can also pass in multiple input strings as a list:
+
+   ```bash
+   curl http://localhost:8080/v1/embeddings \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
+    -d '{
+       "model": "ada-002",
+       "input": ["This is a test sentence.", "This is another test sentence"]
+    }'
+   ```
+
    Model Mapping:
 
    | GPT Model | Gemini Model |
@@ -105,6 +129,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
    | gpt-4 | gemini-1.5-flash-latest |
    | gpt-4-turbo-preview | gemini-1.5-pro-latest |
    | gpt-4-vision-preview | gemini-1.0-pro-vision-latest |
+   | ada-002 | text-embedding-004 |
 
    If you wish to map `gpt-4-vision-preview` to `gemini-1.5-pro-latest`, you can configure the environment variable `GPT_4_VISION_PREVIEW = gemini-1.5-pro-latest`. This is because `gemini-1.5-pro-latest` now also supports multi-modal data.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Gemini-OpenAI-Proxy is a proxy designed to convert the OpenAI API protocol to the Google Gemini protocol. This enables applications built for the OpenAI API to seamlessly communicate with the Gemini protocol, including support for Chat Completion, Embeddings, and Model(s) endpoints.
 
+This is a fork of zhu327/gemini-openai-proxy that eliminates the mapping of openAI models to gemini models and directly exposes the underlying gemini models to the api endpoints directly. I've also added support for Google's embeddings model. This was motivated by my own issues with using Google's [openAI API Compatible Endpoint](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library).
+
 ---
 
 ## Table of Contents
@@ -30,11 +32,24 @@ go build -o gemini main.go
 
 We recommend deploying Gemini-OpenAI-Proxy using Docker for a straightforward setup. Follow these steps to deploy with Docker:
 
-```bash
-docker run --restart=always -it -d -p 8080:8080 --name gemini zhu327/gemini-openai-proxy:latest
-```
+   You can either do this on the command line:
+   ```bash
+   docker run --restart=unless-stopped -it -d -p 8080:8080 --name gemini ghcr.io/ekatiyar/gemini-openai-proxy:latest
+   ```
 
-Adjust the port mapping (e.g., `-p 8080:8080`) as needed, and ensure that the Docker image version (`zhu327/gemini-openai-proxy:latest`) aligns with your requirements.
+   Or with the following docker-compose config:
+   ```yaml
+   version: '3'
+   services:
+      gemini:
+         container_name: gemini
+         ports:
+            - "8080:8080"
+         image: ghcr.io/ekatiyar/gemini-openai-proxy:latest
+         restart: unless-stopped
+   ```
+
+Adjust the port mapping (e.g., `-p 5001:8080`) as needed, and ensure that the Docker image version aligns with your requirements. If you only want the added embedding model support and still want open ai model mapping, use `ghcr.io/ekatiyar/gemini-openai-proxy:embedding` instead
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
     -d '{
-        "model": "gpt-3.5-turbo",
+        "model": "gemini-1.0-pro-latest",
         "messages": [{"role": "user", "content": "Say this is a test!"}],
         "temperature": 0.7
     }'
@@ -70,7 +70,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
     -d '{
-        "model": "gpt-4-vision-preview",
+        "model": "gemini-1.5-vision-latest",
         "messages": [{"role": "user", "content": [
            {"type": "text", "text": "What’s in this image?"},
            {
@@ -83,6 +83,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
         "temperature": 0.7
     }'
    ```
+   If you wish to map `gemini-1.5-vision-latest` to `gemini-1.5-pro-latest`, you can configure the environment variable `GEMINI_VISION_PREVIEW = gemini-1.5-pro-latest`. This is because `gemini-1.5-pro-latest` now also supports multi-modal data. Otherwise, the default is to use the `gemini-1.5-flash-latest` model
 
    If you already have access to the Gemini 1.5 Pro api, you can use:
 
@@ -91,7 +92,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
     -d '{
-        "model": "gpt-4-turbo-preview",
+        "model": "gemini-1.5-pro-latest",
         "messages": [{"role": "user", "content": "Say this is a test!"}],
         "temperature": 0.7
     }'
@@ -104,7 +105,7 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
     -d '{
-       "model": "ada-002",
+       "model": "text-embedding-004",
        "input": "This is a test sentence."
     }'
    ```
@@ -116,22 +117,11 @@ Gemini-OpenAI-Proxy offers a straightforward way to integrate OpenAI functionali
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $YOUR_GOOGLE_AI_STUDIO_API_KEY" \
     -d '{
-       "model": "ada-002",
+       "model": "text-embedding-004",
        "input": ["This is a test sentence.", "This is another test sentence"]
     }'
    ```
 
-   Model Mapping:
-
-   | GPT Model | Gemini Model |
-   |---|---|
-   | gpt-3.5-turbo | gemini-1.0-pro-latest |
-   | gpt-4 | gemini-1.5-flash-latest |
-   | gpt-4-turbo-preview | gemini-1.5-pro-latest |
-   | gpt-4-vision-preview | gemini-1.0-pro-vision-latest |
-   | ada-002 | text-embedding-004 |
-
-   If you wish to map `gpt-4-vision-preview` to `gemini-1.5-pro-latest`, you can configure the environment variable `GPT_4_VISION_PREVIEW = gemini-1.5-pro-latest`. This is because `gemini-1.5-pro-latest` now also supports multi-modal data.
 
 4. **Handle Responses:**
    Process the responses from the Gemini-OpenAI-Proxy in the same way you would handle responses from OpenAI.

--- a/api/handler.go
+++ b/api/handler.go
@@ -26,31 +26,31 @@ func ModelListHandler(c *gin.Context) {
 		"data": []any{
 			openai.Model{
 				CreatedAt: 1686935002,
-				ID:        openai.GPT3Dot5Turbo,
+				ID:        adapter.Gemini1Pro,
 				Object:    "model",
-				OwnedBy:   "openai",
+				OwnedBy:   "google",
 			},
 			openai.Model{
 				CreatedAt: 1686935002,
-				ID:        openai.GPT4,
+				ID:        adapter.Gemini1Dot5Flash,
 				Object:    "model",
-				OwnedBy:   "openai",
+				OwnedBy:   "google",
 			},
 			openai.Model{
 				CreatedAt: 1686935002,
-				ID:        openai.GPT4TurboPreview,
+				ID:        adapter.Gemini1Dot5Pro,
 				Object:    "model",
-				OwnedBy:   "openai",
+				OwnedBy:   "google",
 			},
 			openai.Model{
 				CreatedAt: 1686935002,
-				ID:        openai.GPT4VisionPreview,
+				ID:        adapter.Gemini1Dot5ProV,
 				Object:    "model",
-				OwnedBy:   "openai",
+				OwnedBy:   "google",
 			},
 			openai.Model{
 				CreatedAt: 1686935002,
-				ID:        openai.GPT3Ada002,
+				ID:        adapter.TextEmbedding004,
 				Object:    "model",
 				OwnedBy:   "openai",
 			},
@@ -64,7 +64,7 @@ func ModelRetrieveHandler(c *gin.Context) {
 		CreatedAt: 1686935002,
 		ID:        model,
 		Object:    "model",
-		OwnedBy:   "openai",
+		OwnedBy:   "google",
 	})
 }
 

--- a/api/router.go
+++ b/api/router.go
@@ -24,4 +24,7 @@ func Register(router *gin.Engine) {
 
 	// openai chat
 	router.POST("/v1/chat/completions", ChatProxyHandler)
+
+	// openai embeddings
+	router.POST("/v1/embeddings", EmbeddingProxyHandler)
 }

--- a/pkg/adapter/chat.go
+++ b/pkg/adapter/chat.go
@@ -20,6 +20,7 @@ const (
 	Gemini1Pro       = "gemini-1.0-pro-latest"
 	Gemini1Dot5Pro   = "gemini-1.5-pro-latest"
 	Gemini1Dot5Flash = "gemini-1.5-flash-latest"
+	Gemini1Dot5ProV  = "gemini-1.5-vision-latest" // Converted to one of the above models in struct::ToGenaiModel
 	TextEmbedding004 = "text-embedding-004"
 
 	genaiRoleUser  = "user"

--- a/pkg/adapter/struct.go
+++ b/pkg/adapter/struct.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/google/generative-ai-go/genai"
 	"github.com/pkg/errors"
@@ -45,25 +44,21 @@ type ChatCompletionRequest struct {
 
 func (req *ChatCompletionRequest) ToGenaiModel() string {
 	switch {
-	case req.Model == openai.GPT4VisionPreview:
-		if os.Getenv("GPT_4_VISION_PREVIEW") == Gemini1Dot5Pro {
+	case req.Model == Gemini1Dot5ProV:
+		if os.Getenv("GEMINI_VISION_PREVIEW") == Gemini1Dot5Pro {
 			return Gemini1Dot5Pro
 		}
 
 		return Gemini1Dot5Flash
-	case req.Model == openai.GPT4TurboPreview || req.Model == openai.GPT4Turbo1106 || req.Model == openai.GPT4Turbo0125:
-		return Gemini1Dot5Pro
-	case strings.HasPrefix(req.Model, openai.GPT4):
-		return Gemini1Dot5Flash
 	default:
-		return Gemini1Pro
+		return req.Model
 	}
 }
 
 func (req *ChatCompletionRequest) ToGenaiMessages() ([]*genai.Content, error) {
-	if req.Model == openai.GPT4VisionPreview {
+	if req.Model == Gemini1Dot5ProV {
 		return req.toVisionGenaiContent()
-	} else if req.Model == openai.GPT3Ada002 {
+	} else if req.Model == TextEmbedding004 {
 		return nil, errors.New("Chat Completion is not supported for embedding model")
 	}
 
@@ -209,7 +204,7 @@ type EmbeddingRequest struct {
 }
 
 func (req *EmbeddingRequest) ToGenaiMessages() ([]*genai.Content, error) {
-	if req.Model != openai.GPT3Ada002 {
+	if req.Model != TextEmbedding004 {
 		return nil, errors.New("Embedding is not supported for chat model " + req.Model)
 	}
 


### PR DESCRIPTION
Addresses #35 

This change eliminates the mapping of openAI models to gemini models and directly exposes the underlying gemini models to the api endpoints directly. This was motivated by my own issues with using Google's [openAI API Compatible Endpoint](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library).

My own usecase is flexible enough to use non-openAI named models with the OpenAI API, so the model mapping from openAI model names to gemini model names just serves to confuse things.

I recognize this may not be the case for all users of this project and some clients may only be able to handle OpenAI-named models; in that case feel free to reject this PR.