### PR TITLE
fix: replace empty content with space in system message handling

### DIFF
--- a/pkg/adapter/struct.go
+++ b/pkg/adapter/struct.go
@@ -75,7 +75,7 @@ func (req *ChatCompletionRequest) toVisionGenaiContent() ([]*genai.Content, erro
 				},
 				{
 					Parts: []genai.Part{
-						genai.Text(""),
+						genai.Text(" "),
 					},
 					Role: genaiRoleModel,
 				},


### PR DESCRIPTION
- Replace genai.Text("") with genai.Text(" ") to avoid empty content error
- Empty content is not allowed in the API, using single space as minimum valid content
- This change affects system message processing where an empty model response was previously used

BREAKING CHANGE: None